### PR TITLE
이미지 뷰 개선, Text가 없는 선택지에서 null 에러 발생 버그 수정

### DIFF
--- a/lib/education/component/image_list_builder.dart
+++ b/lib/education/component/image_list_builder.dart
@@ -17,11 +17,22 @@ class ImageListBuilder extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         itemCount: images.length,
         shrinkWrap: true,
-        itemBuilder: (context, index) => SizedBox(
-          height: 50,
-          child: Image.network(
-            images[index],
-            fit: BoxFit.cover,
+        itemBuilder: (context, index) => InkWell(
+          onTap: () => showDialog(
+            context: context,
+            builder: (context) => Center(
+              child: Image.network(
+                images[index],
+                fit: BoxFit.contain,
+              ),
+            ),
+          ),
+          child: SizedBox(
+            height: 80,
+            child: Image.network(
+              images[index],
+              fit: BoxFit.cover,
+            ),
           ),
         ),
       ),

--- a/lib/quiz/component/option_card.dart
+++ b/lib/quiz/component/option_card.dart
@@ -20,7 +20,7 @@ class OptionCard extends StatelessWidget {
 
     if (isSelected) {
       buttonColor = selectedOptionButtonColor;
-    } else if (description!.isEmpty) {
+    } else if (description == null || description!.isEmpty) {
       buttonColor = Colors.grey;
     } else {
       buttonColor = Colors.white;


### PR DESCRIPTION
## 이미지 뷰 개선

![IMG_35E687522C80-1](https://github.com/GSC-2024-Hongik-Team-6/safety-mobile/assets/103521468/b2f85469-7cef-460b-ba6b-28c9247b764a)

![IMG_1D2E6FF6E248-1](https://github.com/GSC-2024-Hongik-Team-6/safety-mobile/assets/103521468/c3798a42-da3e-48c0-be0b-dedd7e3b8cbf)

이미지 list view의 크기 확대
이미지를 눌렀을 시 모달창으로 이미지가 크게 뜸

---

## Text 없는 Option이 있는 QuizDetailView에서 에러 발생 버그 수정

null 체크 로직 추가